### PR TITLE
feat(687): implement _notify for slack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const Joi = require('joi');
+const slacker = require('./slack');
+const NotificationBase = require('screwdriver-notifications-base');
+
+const COLOR_MAP = {
+    SUCCESS: 'good',
+    FAILURE: 'danger',
+    ABORTED: 'danger',
+    // https://github.com/screwdriver-cd/ui/blob/master/app/styles/screwdriver-colors.scss
+    RUNNING: '#0F69FF',
+    QUEUED: '#0F69FF'
+};
+const DEFAULT_STATUSES = ['FAILURE'];
+const SCHEMA_STATUS = Joi.string().valid(Object.keys(COLOR_MAP));
+const SCHEMA_STATUSES = Joi.array()
+    .items(SCHEMA_STATUS)
+    .min(0);
+const SCHEMA_SLACK_CHANNEL = Joi.string().required();
+const SCHEMA_SLACK_CHANNELS = Joi.array()
+    .items(SCHEMA_SLACK_CHANNEL)
+    .min(1);
+const SCHEMA_SLACK_SETTINGS = Joi.object().keys({
+    slack: Joi.alternatives().try(
+        Joi.object().keys({ channels: SCHEMA_SLACK_CHANNELS, statuses: SCHEMA_STATUSES }),
+        SCHEMA_SLACK_CHANNELS, SCHEMA_SLACK_CHANNEL
+    )
+}).unknown(true);
+const SCHEMA_BUILD_DATA = Joi.object()
+    .keys({
+        settings: SCHEMA_SLACK_SETTINGS.required(),
+        status: SCHEMA_STATUS.required(),
+        pipelineName: Joi.string(),
+        jobName: Joi.string(),
+        buildId: Joi.number().integer(),
+        buildLink: Joi.string()
+    });
+const SCHEMA_SLACK_CONFIG = Joi.object()
+    .keys({
+        token: Joi.string().required()
+    });
+
+class SlackNotifier extends NotificationBase {
+    /**
+    * Constructs an SlackNotifier
+    * @constructor
+    * @param {object} config - Screwdriver config object initialized in API
+    */
+    constructor(config) {
+        super(...arguments);
+        this.config = Joi.attempt(config, SCHEMA_SLACK_CONFIG,
+            'Invalid config for slack notifications');
+    }
+    /**
+    * Sets listener on server event of name 'eventName' in Screwdriver
+    * Currently, event is triggered with a build status is updated
+    * @method _notify
+    * @param {Object} buildData - Build data emitted with some event from Screwdriver
+    */
+    _notify(buildData) {
+        // Check buildData format against SCHEMA_BUILD_DATA
+        try {
+            Joi.attempt(buildData, SCHEMA_BUILD_DATA, 'Invalid build data format');
+        } catch (e) {
+            return;
+        }
+        if (typeof buildData.settings.slack === 'string' ||
+            Array.isArray(buildData.settings.slack)) {
+            buildData.settings.slack = (typeof buildData.settings.slack === 'string')
+                ? [buildData.settings.slack]
+                : buildData.settings.slack;
+            buildData.settings.slack = {
+                channels: buildData.settings.slack,
+                statuses: DEFAULT_STATUSES
+            };
+        }
+
+        if (!buildData.settings.slack.statuses.includes(buildData.status)) {
+            return;
+        }
+        const pipelineLink = buildData.buildLink.split('/builds')[0];
+        const message = `<${pipelineLink}|${buildData.jobName}> *${buildData.status}*`;
+        const attachment = [
+            {
+                fallback: '',
+                color: COLOR_MAP[buildData.status],
+                fields: [
+                    {
+                        title: 'Build',
+                        value: `<${buildData.buildLink}|#${buildData.buildId}>`,
+                        short: true
+                    }
+                ]
+            }
+        ];
+        const slackMessage = {
+            message,
+            attachment
+        };
+
+        slacker(this.config.token, buildData.settings.slack.channels, slackMessage);
+    }
+}
+
+module.exports = SlackNotifier;

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class SlackNotifier extends NotificationBase {
             return;
         }
         const pipelineLink = buildData.buildLink.split('/builds')[0];
-        const message = `<${pipelineLink}|${buildData.jobName}> *${buildData.status}*`;
+        const message = `<${pipelineLink}|${buildData.pipelineName}#${buildData.jobName}> *${buildData.status}*`;
         const attachments = [
             {
                 fallback: '',

--- a/index.js
+++ b/index.js
@@ -80,6 +80,8 @@ class SlackNotifier extends NotificationBase {
             return;
         }
         const pipelineLink = buildData.buildLink.split('/builds')[0];
+
+        // eslint-disable-next-line max-len
         const message = `<${pipelineLink}|${buildData.pipelineName}#${buildData.jobName}> *${buildData.status}*`;
         const attachments = [
             {

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ class SlackNotifier extends NotificationBase {
         }
         const pipelineLink = buildData.buildLink.split('/builds')[0];
         const message = `<${pipelineLink}|${buildData.jobName}> *${buildData.status}*`;
-        const attachment = [
+        const attachments = [
             {
                 fallback: '',
                 color: COLOR_MAP[buildData.status],
@@ -96,7 +96,7 @@ class SlackNotifier extends NotificationBase {
         ];
         const slackMessage = {
             message,
-            attachment
+            attachments
         };
 
         slacker(this.config.token, buildData.settings.slack.channels, slackMessage);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,16 @@
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@slack/client": "^3.15.0",
+    "hapi": "^16.0.0",
+    "hoek": "^5.0.2",
+    "joi": "^13.1.0",
+    "mockery": "^2.1.0",
+    "request": "^2.83.0",
+    "screwdriver-notifications-base": "^3.0.0",
+    "sinon": "^4.1.6"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/slack.js
+++ b/slack.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const hoek = require('hoek');
-const WebClient = require('@slack/client');
+const { WebClient } = require('@slack/client');
 
 let web;
 
@@ -36,7 +36,7 @@ function postMessage(channelName, payload) {
             }
 
             return web.chat.postMessage(id, payload.message, {
-                as_true: true,
+                as_user: true,
                 attachments: payload.attachments
             });
         })

--- a/slack.js
+++ b/slack.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const hoek = require('hoek');
+const WebClient = require('@slack/client');
+
+let web;
+
+/**
+ * Retrieves the channel id
+ * @param {String} channelName             slack channel name
+ * @return {Promise}                       the channel id
+ */
+function getChannelId(channelName) {
+    const config = {
+        exclude_archived: true,
+        exclude_members: true
+    };
+
+    return web.channels.list(config)
+        .then(res => hoek.reach(res.channels.find(c => c.name === channelName), 'id'));
+}
+
+/**
+ * Post message to a specific channel
+ * @method postMessage
+ * @param {String} channelName      name of the channel
+ * @param {Object} payload          payload of the slack message
+ * @return {Promise}
+ */
+function postMessage(channelName, payload) {
+    return getChannelId(channelName)
+        .then((id) => {
+            if (!id) {
+                // eslint-disable-next-line no-console
+                throw new Error(`Channel ID not found for: ${channelName}`);
+            }
+
+            return web.chat.postMessage(id, payload.message, {
+                as_true: true,
+                attachments: payload.attachments
+            });
+        })
+        // eslint-disable-next-line no-console
+        .catch(err => console.error(err.message));
+}
+
+/**
+ * Sends slack message to slack channels
+ * @param {String} token                   access token for slack
+ * @param {String[]} channels              slack channel names
+ * @param {Object} payload
+ * @return {Promise}
+ */
+function slacker(token, channels, payload) {
+    if (!web) {
+        web = new WebClient(token);
+    }
+
+    return Promise.all(channels.map(channelName => postMessage(channelName, payload)));
+}
+
+module.exports = slacker;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,271 @@
 'use strict';
 
+const Hapi = require('hapi');
 const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
 
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+sinon.assert.expose(assert, { prefix: '' });
+describe('index', () => {
+    const eventMock = 'build_status_test';
+
+    let SlackNotifier;
+    let serverMock;
+    let configMock;
+    let notifier;
+    let buildDataMock;
+    let WebClientMock;
+    let WebClientConstructorMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        WebClientMock = {
+            channels: {
+                list: sinon.stub().resolves({
+                    channels: [{
+                        name: 'meeseeks',
+                        id: '23'
+                    }]
+                })
+            },
+            chat: {
+                postMessage: sinon.stub().resolves('fffff')
+            }
+        };
+        WebClientConstructorMock = sinon.stub().returns(WebClientMock);
+        mockery.registerMock('@slack/client', WebClientConstructorMock);
+
+        // eslint-disable-next-line global-require
+        SlackNotifier = require('../index');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('notifier listens to server emits', () => {
+        beforeEach(() => {
+            serverMock = new Hapi.Server();
+            configMock = {
+                token: 'y353e5y45'
+            };
+            buildDataMock = {
+                settings: {
+                    slack: {
+                        channels: ['meeseeks', 'caaaandoooo', 'aaa'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'SUCCESS',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+            notifier = new SlackNotifier(configMock);
+        });
+
+        it('verifies that included status creates slack notifier', (done) => {
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMock);
+
+            process.nextTick(() => {
+                assert.calledWith(WebClientConstructorMock, configMock.token);
+                assert.calledThrice(WebClientMock.channels.list);
+                done();
+            });
+        });
+
+        it('verifies that non-included status does not send a notification', (done) => {
+            const buildDataMockUnincluded = {
+                settings: {
+                    slack: {
+                        channels: ['meeseeks', 'caaaandoooo', 'aaa', 'fddfdfdf'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'invalid_status',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMockUnincluded);
+
+            process.nextTick(() => {
+                assert.notCalled(WebClientConstructorMock);
+                done();
+            });
+        });
+
+        it('verifies that non-subscribed status does not send a notifcation', (done) => {
+            const buildDataMockUnincluded = {
+                settings: {
+                    slack: {
+                        channels: ['meeseeks', 'caaaandoooo', 'aaa', 'fddfdfdf'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'ABORTED'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMockUnincluded);
+
+            process.nextTick(() => {
+                assert.notCalled(WebClientConstructorMock);
+                done();
+            });
+        });
+
+        it('sets channels and statuses for simple slack string name', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledOnce(WebClientMock.channels.list);
+                done();
+            });
+        });
+
+        it('sets channels and statuses for an array of channels in config settings', (done) => {
+            const buildDataMockArray = {
+                settings: {
+                    slack: ['meeseeks', 'abcde']
+                },
+                status: 'FAILURE',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMockArray);
+
+            process.nextTick(() => {
+                assert.calledTwice(WebClientMock.channels.list);
+                done();
+            });
+        });
+
+        it('allows additional notifications plugins in buildData.settings', (done) => {
+            buildDataMock.settings.hipchat = {
+                awesome: 'sauce',
+                catch: 22
+            };
+
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMock);
+
+            process.nextTick(() => {
+                assert.calledWith(WebClientConstructorMock, configMock.token);
+                done();
+            });
+        });
+    });
+
+    describe('config is validated', () => {
+        it('validates token', () => {
+            configMock = {};
+            try {
+                notifier = new SlackNotifier(configMock);
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+    });
+
+    describe('buildData is validated', () => {
+        beforeEach(() => {
+            serverMock = new Hapi.Server();
+            configMock = {
+                token: 'faketoken'
+            };
+            buildDataMock = {
+                settings: {
+                    slack: {
+                        channels: ['notifyme', 'notifyyou'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'SUCCESS',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            notifier = new SlackNotifier(configMock);
+        });
+
+        it('validates status', (done) => {
+            buildDataMock.status = 22;
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMock);
+
+            process.nextTick(() => {
+                assert.notCalled(WebClientConstructorMock);
+                done();
+            });
+        });
+
+        it('validates slack settings', (done) => {
+            buildDataMock.settings.slack = { room: 'wrongKey' };
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMock);
+
+            process.nextTick(() => {
+                assert.notCalled(WebClientConstructorMock);
+                done();
+            });
+        });
+
+        it('validates buildData format', (done) => {
+            const buildDataMockInvalid = ['this', 'is', 'wrong'];
+
+            serverMock.event(eventMock);
+            serverMock.on(eventMock, data => notifier.notify(data));
+            serverMock.emit(eventMock, buildDataMockInvalid);
+
+            process.nextTick(() => {
+                assert.notCalled(WebClientConstructorMock);
+                done();
+            });
+        });
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,7 +38,10 @@ describe('index', () => {
                 postMessage: sinon.stub().resolves('fffff')
             }
         };
-        WebClientConstructorMock = sinon.stub().returns(WebClientMock);
+
+        WebClientConstructorMock = {
+            WebClient: sinon.stub().returns(WebClientMock)
+        };
         mockery.registerMock('@slack/client', WebClientConstructorMock);
 
         // eslint-disable-next-line global-require
@@ -82,7 +85,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
-                assert.calledWith(WebClientConstructorMock, configMock.token);
+                assert.calledWith(WebClientConstructorMock.WebClient, configMock.token);
                 assert.calledThrice(WebClientMock.channels.list);
                 done();
             });
@@ -108,7 +111,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMockUnincluded);
 
             process.nextTick(() => {
-                assert.notCalled(WebClientConstructorMock);
+                assert.notCalled(WebClientConstructorMock.WebClient);
                 done();
             });
         });
@@ -129,7 +132,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMockUnincluded);
 
             process.nextTick(() => {
-                assert.notCalled(WebClientConstructorMock);
+                assert.notCalled(WebClientConstructorMock.WebClient);
                 done();
             });
         });
@@ -189,7 +192,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
-                assert.calledWith(WebClientConstructorMock, configMock.token);
+                assert.calledWith(WebClientConstructorMock.WebClient, configMock.token);
                 done();
             });
         });
@@ -238,7 +241,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
-                assert.notCalled(WebClientConstructorMock);
+                assert.notCalled(WebClientConstructorMock.WebClient);
                 done();
             });
         });
@@ -250,7 +253,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
-                assert.notCalled(WebClientConstructorMock);
+                assert.notCalled(WebClientConstructorMock.WebClient);
                 done();
             });
         });
@@ -263,7 +266,7 @@ describe('index', () => {
             serverMock.emit(eventMock, buildDataMockInvalid);
 
             process.nextTick(() => {
-                assert.notCalled(WebClientConstructorMock);
+                assert.notCalled(WebClientConstructorMock.WebClient);
                 done();
             });
         });

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -53,7 +53,7 @@ describe('slack', () => {
         mockery.disable();
     });
 
-    describe('notifier listens to server emits', () => {
+    describe('slacker posts message to channels', () => {
         beforeEach(() => {
             configMock = {
                 token: 'y353e5y45'

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -37,7 +37,9 @@ describe('slack', () => {
                 postMessage: sinon.stub().resolves({})
             }
         };
-        WebClientConstructorMock = sinon.stub().returns(WebClientMock);
+        WebClientConstructorMock = {
+            WebClient: sinon.stub().returns(WebClientMock)
+        };
         mockery.registerMock('@slack/client', WebClientConstructorMock);
 
         // eslint-disable-next-line global-require
@@ -68,7 +70,7 @@ describe('slack', () => {
         it('do not create client again if there is one', () =>
             slacker(configMock.token, channels, payload)
                 .then(slacker(configMock.token, channels, payload))
-                .then(assert.calledOnce(WebClientConstructorMock))
+                .then(assert.calledOnce(WebClientConstructorMock.WebClient))
         );
 
         it('gets correct channel ids and post message to channels', () =>
@@ -76,7 +78,7 @@ describe('slack', () => {
                 assert.calledTwice(WebClientMock.channels.list);
                 assert.calledOnce(WebClientMock.chat.postMessage);
                 assert.calledWith(WebClientMock.chat.postMessage, '23', payload.message, {
-                    as_true: true,
+                    as_user: true,
                     attachments: payload.attachments
                 });
             })

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+describe('slack', () => {
+    let configMock;
+    let channels;
+    let payload;
+    let slacker;
+    let WebClientMock;
+    let WebClientConstructorMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        WebClientMock = {
+            channels: {
+                list: sinon.stub().resolves({
+                    channels: [{
+                        name: 'meeseeks',
+                        id: '23'
+                    }, {
+                        name: 'dd',
+                        id: '21'
+                    }]
+                })
+            },
+            chat: {
+                postMessage: sinon.stub().resolves({})
+            }
+        };
+        WebClientConstructorMock = sinon.stub().returns(WebClientMock);
+        mockery.registerMock('@slack/client', WebClientConstructorMock);
+
+        // eslint-disable-next-line global-require
+        slacker = require('../slack');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('notifier listens to server emits', () => {
+        beforeEach(() => {
+            configMock = {
+                token: 'y353e5y45'
+            };
+            channels = ['meeseeks', 'caaaandoooo'];
+            payload = {
+                message: 'build failed',
+                attachments: {}
+            };
+        });
+
+        it('do not create client again if there is one', () =>
+            slacker(configMock.token, channels, payload)
+                .then(slacker(configMock.token, channels, payload))
+                .then(assert.calledOnce(WebClientConstructorMock))
+        );
+
+        it('gets correct channel ids and post message to channels', () =>
+            slacker(configMock.token, channels, payload).then(() => {
+                assert.calledTwice(WebClientMock.channels.list);
+                assert.calledOnce(WebClientMock.chat.postMessage);
+                assert.calledWith(WebClientMock.chat.postMessage, '23', payload.message, {
+                    as_true: true,
+                    attachments: payload.attachments
+                });
+            })
+        );
+    });
+});


### PR DESCRIPTION
# Context

It would be convenient to receive slack notifications when things happen in a pipeline, so users can respond appropriately to successful deploy, or when the pipeline fails.

# Objective

Provide an interface that allows users to receive pipeline notifications via slack. Users specify the channels which should receive notifications, and build statuses that trigger a notification.

### Interface

In `screwdriver.yaml`
```
settings:
        slack: channel_A
```
```
settings:
        slack: [channel_A, channel_B]
```
```
settings:
        slack: 
            channels: 
               - channel_A
               - channel_B
           statuses:
               - SUCCESS
               - FAILURE
               - ABORTED
               - QUEUED
               - RUNNING
```

# Reference

https://github.com/screwdriver-cd/screwdriver/issues/687
