### PR TITLE
fix: use semantic-release template to publish

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
use semantic-release template to publish since the latest semantic release requires node 8