### PR TITLE
fix: Set max number of retries to 5

### DIFF
--- a/slack.js
+++ b/slack.js
@@ -55,7 +55,13 @@ function postMessage(channelName, payload) {
  */
 function slacker(token, channels, payload) {
     if (!web) {
-        web = new WebClient(token);
+        web = new WebClient(token, {
+            retryConfig: {
+                retries: 5,
+                factor: 3.86,
+                maxRetryTime: 30 * 60 * 1000 // Set maximum time to 30 min that the retried operation is allowed to run
+            }
+        });
     }
 
     return Promise.all(channels.map(channelName => postMessage(channelName, payload)));


### PR DESCRIPTION
## Context
The [default retry config is set to forever with exponential backoff](https://slackapi.github.io/node-slack-sdk/web_api#changing-the-retry-configuration). This is causing *rate_limiting errors* for us. We should set a more reasonable max number of retries.

```
[INFO] @slack/client:WebClient0 API Call failed due to rate limiting. Will retry in 3 seconds.
```

## Objective
This PR sets more reasonable retry options. 

## Related links
- Retry options: https://github.com/tim-kos/node-retry#tutorial
- Current default retry option: https://github.com/slackapi/node-slack-sdk/blob/fec79509a10ed574c260c3bea68b839bd46970c1/src/retry-policies.ts#L30
- Slack client docs: https://slackapi.github.io/node-slack-sdk/web_api#changing-the-retry-configuration