### PR TITLE
fix: Use channel name to post Slack notification, avoid rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Noticiations (Slack)
+# Notifications (Slack)
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
 > Sends slack notifications on certain build events
@@ -6,7 +6,7 @@
 ## Usage
 
 ```bash
-npm install screwdriver-notification-slacks
+npm install screwdriver-notifications-slack
 ```
 
 ## Testing

--- a/slack.js
+++ b/slack.js
@@ -1,24 +1,8 @@
 'use strict';
 
-const hoek = require('hoek');
 const { WebClient } = require('@slack/client');
 
 let web;
-
-/**
- * Retrieves the channel id
- * @param {String} channelName             slack channel name
- * @return {Promise}                       the channel id
- */
-function getChannelId(channelName) {
-    const config = {
-        exclude_archived: true,
-        exclude_members: true
-    };
-
-    return web.channels.list(config)
-        .then(res => hoek.reach(res.channels.find(c => c.name === channelName), 'id'));
-}
 
 /**
  * Post message to a specific channel
@@ -28,20 +12,13 @@ function getChannelId(channelName) {
  * @return {Promise}
  */
 function postMessage(channelName, payload) {
-    return getChannelId(channelName)
-        .then((id) => {
-            if (!id) {
-                // eslint-disable-next-line no-console
-                throw new Error(`Channel ID not found for: ${channelName}`);
-            }
-
-            return web.chat.postMessage({
-                channel: id,
-                text: payload.message,
-                as_user: true,
-                attachments: payload.attachments
-            });
-        })
+    // Can post to channel name directly https://api.slack.com/methods/chat.postMessage#channels
+    return web.chat.postMessage({
+        channel: channelName,
+        text: payload.message,
+        as_user: true,
+        attachments: payload.attachments
+    })
         // eslint-disable-next-line no-console
         .catch(err => console.error(err.message));
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,7 +86,7 @@ describe('index', () => {
 
             process.nextTick(() => {
                 assert.calledWith(WebClientConstructorMock.WebClient, configMock.token);
-                assert.calledThrice(WebClientMock.channels.list);
+                assert.calledThrice(WebClientMock.chat.postMessage);
                 done();
             });
         });
@@ -116,7 +116,7 @@ describe('index', () => {
             });
         });
 
-        it('verifies that non-subscribed status does not send a notifcation', (done) => {
+        it('verifies that non-subscribed status does not send a notification', (done) => {
             const buildDataMockUnincluded = {
                 settings: {
                     slack: {
@@ -154,7 +154,7 @@ describe('index', () => {
             serverMock.events.emit(eventMock, buildDataMockSimple);
 
             process.nextTick(() => {
-                assert.calledOnce(WebClientMock.channels.list);
+                assert.calledOnce(WebClientMock.chat.postMessage);
                 done();
             });
         });
@@ -176,7 +176,7 @@ describe('index', () => {
             serverMock.events.emit(eventMock, buildDataMockArray);
 
             process.nextTick(() => {
-                assert.calledTwice(WebClientMock.channels.list);
+                assert.calledTwice(WebClientMock.chat.postMessage);
                 done();
             });
         });

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -67,7 +67,7 @@ describe('slack', () => {
             };
         });
 
-        it('do not create client again if there is one', () =>
+        it('does not create client again if there is one', () =>
             slacker(configMock.token, channels, payload)
                 .then(slacker(configMock.token, channels, payload))
                 .then(assert.calledOnce(WebClientConstructorMock.WebClient))
@@ -75,15 +75,31 @@ describe('slack', () => {
 
         it('gets correct channel ids and post message to channels', () =>
             slacker(configMock.token, channels, payload).then(() => {
-                assert.calledTwice(WebClientMock.channels.list);
-                assert.calledOnce(WebClientMock.chat.postMessage);
-                assert.calledWith(WebClientMock.chat.postMessage, {
-                    channel: '23',
+                assert.calledTwice(WebClientMock.chat.postMessage);
+                assert.calledWith(WebClientMock.chat.postMessage.firstCall, {
+                    channel: 'meeseeks',
+                    text: payload.message,
+                    as_user: true,
+                    attachments: payload.attachments
+                });
+                assert.calledWith(WebClientMock.chat.postMessage.secondCall, {
+                    channel: 'caaaandoooo',
                     text: payload.message,
                     as_user: true,
                     attachments: payload.attachments
                 });
             })
         );
+
+        it('logs an error if cannt post message to channels', () => {
+            WebClientMock.chat.postMessage.rejects(new Error('error!'));
+
+            return slacker(configMock.token, channels, payload).then(() => {
+                it('should catch an error', () => {
+                    // eslint-disable-next-line no-console
+                    assert.calledTwice(console.error);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
## Context
We're getting rate limited from Slack for all our calls to `channels.list`. We make these calls every time we post notifications to Slack in order to get the channel ID. After further research, it looks like you don't need the channel ID in order to post a message. 

## Objective
This PR removes calls to `channels.list` in favor of just posting to the channel name directly. The `chat.postMessage` endpoint has a much more relaxed rate limit (1 message per second to a specific channel, which translates into several hundred messages per minute; much better than the 20 per minute per workspace for `channels.list`), which should also help our rate limiting issue. 

_Note: The documentation says you need a `#` before the channel name for a public channel and no `#` for a private one, but when I tried running this locally it worked just fine for both public and private channels when I omitted the `#`._

## Related links
- Slack API docs: https://api.slack.com/methods/chat.postMessage#channels
- Slack rate limits docs: https://api.slack.com/docs/rate-limits#tier_t2
- Related to https://github.com/screwdriver-cd/notifications-slack/pull/10