### PR TITLE
feat: Enrich notification message

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,13 @@ const COLOR_MAP = {
     RUNNING: '#0F69FF',
     QUEUED: '#0F69FF'
 };
+const STATUSES_MAP = {
+    SUCCESS: ':sunny:',
+    FAILURE: ':umbrella:',
+    ABORTED: ':cloud:',
+    RUNNING: ':runner:',
+    QUEUED: ':cyclone:'
+};
 const DEFAULT_STATUSES = ['FAILURE'];
 const SCHEMA_STATUS = Joi.string().valid(Object.keys(COLOR_MAP));
 const SCHEMA_STATUSES = Joi.array()
@@ -94,17 +101,19 @@ class SlackNotifier extends NotificationBase {
             return;
         }
         const pipelineLink = buildData.buildLink.split('/builds')[0];
-
-        // eslint-disable-next-line max-len
-        const message = `<${pipelineLink}|${buildData.pipeline.scmRepo.name}#${buildData.jobName}> *${buildData.status}*`;
+        const truncatedSha = buildData.event.sha.slice(0, 6);
+        const message = `*${buildData.status}* ${STATUSES_MAP[buildData.status]}`;
         const attachments = [
             {
                 fallback: '',
                 color: COLOR_MAP[buildData.status],
                 fields: [
                     {
-                        title: 'Build',
-                        value: `<${buildData.buildLink}|#${buildData.build.id}>`,
+                        // eslint-disable-next-line max-len
+                        title: `<${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}> <${buildData.buildLink}|#${buildData.build.id}>`,
+                        // eslint-disable-next-line max-len
+                        value: `${buildData.event.commit.message} (${buildData.event.commit.url}|${truncatedSha}>)` +
+                                `\n${buildData.event.causeMessage}`,
                         short: true
                     }
                 ]

--- a/index.js
+++ b/index.js
@@ -104,6 +104,10 @@ class SlackNotifier extends NotificationBase {
         const truncatedSha = buildData.event.sha.slice(0, 6);
         // eslint-disable-next-line max-len
         const message = `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
+        const cutOff = 150;
+        const commitMessage = buildData.event.commit.message.length > cutOff ?
+            `${buildData.event.commit.message.substring(0, cutOff)}...` :
+            buildData.event.commit.message;
         const attachments = [
             {
                 fallback: '',
@@ -111,7 +115,7 @@ class SlackNotifier extends NotificationBase {
                 title: `#${buildData.build.id}`,
                 title_link: `${buildData.buildLink}`,
                 // eslint-disable-next-line max-len
-                text: `${buildData.event.commit.message} (<${buildData.event.commit.url}|${truncatedSha}>)` +
+                text: `${commitMessage} (<${buildData.event.commit.url}|${truncatedSha}>)` +
                         `\n${buildData.event.causeMessage}`
             }
         ];

--- a/index.js
+++ b/index.js
@@ -102,21 +102,17 @@ class SlackNotifier extends NotificationBase {
         }
         const pipelineLink = buildData.buildLink.split('/builds')[0];
         const truncatedSha = buildData.event.sha.slice(0, 6);
-        const message = `*${buildData.status}* ${STATUSES_MAP[buildData.status]}`;
+        // eslint-disable-next-line max-len
+        const message = `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
         const attachments = [
             {
                 fallback: '',
                 color: COLOR_MAP[buildData.status],
-                fields: [
-                    {
-                        // eslint-disable-next-line max-len
-                        title: `<${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}> <${buildData.buildLink}|#${buildData.build.id}>`,
-                        // eslint-disable-next-line max-len
-                        value: `${buildData.event.commit.message} (${buildData.event.commit.url}|${truncatedSha}>)` +
-                                `\n${buildData.event.causeMessage}`,
-                        short: true
-                    }
-                ]
+                title: `#${buildData.build.id}`,
+                title_link: `${buildData.buildLink}`,
+                // eslint-disable-next-line max-len
+                text: `${buildData.event.commit.message} (<${buildData.event.commit.url}|${truncatedSha}>)` +
+                        `\n${buildData.event.causeMessage}`
             }
         ];
         const slackMessage = {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ const SCHEMA_SLACK_CHANNELS = Joi.array()
     .min(1);
 const SCHEMA_SLACK_SETTINGS = Joi.object().keys({
     slack: Joi.alternatives().try(
-        Joi.object().keys({ channels: SCHEMA_SLACK_CHANNELS, statuses: SCHEMA_STATUSES }),
+        Joi.object().keys({
+            channels: SCHEMA_SLACK_CHANNELS,
+            statuses: SCHEMA_STATUSES,
+            minimized: Joi.boolean()
+        }),
         SCHEMA_SLACK_CHANNELS, SCHEMA_SLACK_CHANNEL
     )
 }).unknown(true);
@@ -93,7 +97,8 @@ class SlackNotifier extends NotificationBase {
                 : buildData.settings.slack;
             buildData.settings.slack = {
                 channels: buildData.settings.slack,
-                statuses: DEFAULT_STATUSES
+                statuses: DEFAULT_STATUSES,
+                minimized: false
             };
         }
 
@@ -102,23 +107,41 @@ class SlackNotifier extends NotificationBase {
         }
         const pipelineLink = buildData.buildLink.split('/builds')[0];
         const truncatedSha = buildData.event.sha.slice(0, 6);
-        // eslint-disable-next-line max-len
-        const message = `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
         const cutOff = 150;
         const commitMessage = buildData.event.commit.message.length > cutOff ?
             `${buildData.event.commit.message.substring(0, cutOff)}...` :
             buildData.event.commit.message;
-        const attachments = [
-            {
-                fallback: '',
-                color: COLOR_MAP[buildData.status],
-                title: `#${buildData.build.id}`,
-                title_link: `${buildData.buildLink}`,
-                // eslint-disable-next-line max-len
-                text: `${commitMessage} (<${buildData.event.commit.url}|${truncatedSha}>)` +
-                        `\n${buildData.event.causeMessage}`
-            }
-        ];
+        const isMinimized = buildData.settings.slack.minimized;
+        const message = isMinimized ?
+            // eslint-disable-next-line max-len
+            `<${pipelineLink}|${buildData.pipeline.scmRepo.name}#${buildData.jobName}> *${buildData.status}*` :
+            // eslint-disable-next-line max-len
+            `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
+        const attachments = isMinimized ?
+            [
+                {
+                    fallback: '',
+                    color: COLOR_MAP[buildData.status],
+                    fields: [
+                        {
+                            title: 'Build',
+                            value: `<${buildData.buildLink}|#${buildData.build.id}>`,
+                            short: true
+                        }
+                    ]
+                }
+            ] :
+            [
+                {
+                    fallback: '',
+                    color: COLOR_MAP[buildData.status],
+                    title: `#${buildData.build.id}`,
+                    title_link: `${buildData.buildLink}`,
+                    // eslint-disable-next-line max-len
+                    text: `${commitMessage} (<${buildData.event.commit.url}|${truncatedSha}>)` +
+                            `\n${buildData.event.causeMessage}`
+                }
+            ];
         const slackMessage = {
             message,
             attachments

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,7 +87,8 @@ describe('index', () => {
                     commit: {
                         author: { name: 'foo' },
                         message: 'fixing a bug'
-                    }
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
                 },
                 buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
             };
@@ -132,7 +133,8 @@ describe('index', () => {
                     commit: {
                         author: { name: 'foo' },
                         message: 'fixing a bug'
-                    }
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
                 },
                 buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
             };
@@ -191,7 +193,8 @@ describe('index', () => {
                     commit: {
                         author: { name: 'foo' },
                         message: 'fixing a bug'
-                    }
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
                 },
                 buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
             };
@@ -229,7 +232,8 @@ describe('index', () => {
                     commit: {
                         author: { name: 'foo' },
                         message: 'fixing a bug'
-                    }
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
                 },
                 buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
             };
@@ -318,7 +322,8 @@ describe('index', () => {
                     commit: {
                         author: { name: 'foo' },
                         message: 'fixing a bug'
-                    }
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
                 },
                 buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
             };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -344,7 +344,7 @@ describe('index', () => {
         });
 
         it('validates slack settings', (done) => {
-            buildDataMock.settings.slack = { room: 'wrongKey' };
+            buildDataMock.settings.slack = { room: 'wrongKey', minimized: true };
             serverMock.event(eventMock);
             serverMock.events.on(eventMock, data => notifier.notify(data));
             serverMock.events.emit(eventMock, buildDataMock);


### PR DESCRIPTION
## Context
Currently, notification message which is sent to slack has little information about a build.
I added commit information to notification message and refine message style.

## Objective
Fix message body and attachment fields.
New notification message like below.
<img width="472" alt="2019-02-22 11 20 52" src="https://user-images.githubusercontent.com/8113204/53215508-4e67dc80-3694-11e9-9987-eb1f163c3acb.png">
