### PR TITLE
feat(1177): Add meta message

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ class SlackNotifier extends NotificationBase {
             `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
 
         const metaMessage = hoek.reach(buildData,
-            'build.meta.notification.message', { default: false });
+            'build.meta.notification.slack.message', { default: false });
 
         if (metaMessage) {
             message = `${message}\n${metaMessage}`;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 const slacker = require('./slack');
 const NotificationBase = require('screwdriver-notifications-base');
+const hoek = require('hoek');
 
 const COLOR_MAP = {
     SUCCESS: 'good',
@@ -115,11 +116,18 @@ class SlackNotifier extends NotificationBase {
             `${buildData.event.commit.message.substring(0, cutOff)}...` :
             buildData.event.commit.message;
         const isMinimized = buildData.settings.slack.minimized;
-        const message = isMinimized ?
-            // eslint-disable-next-line max-len
-            `<${pipelineLink}|${buildData.pipeline.scmRepo.name}#${buildData.jobName}> *${buildData.status}*` :
-            // eslint-disable-next-line max-len
-            `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
+
+        let message = hoek.reach(buildData,
+            'build.meta.notification.message', { default: false });
+
+        if (!message) {
+            message = isMinimized ?
+                // eslint-disable-next-line max-len
+                `<${pipelineLink}|${buildData.pipeline.scmRepo.name}#${buildData.jobName}> *${buildData.status}*` :
+                // eslint-disable-next-line max-len
+                `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
+        }
+
         const attachments = isMinimized ?
             [
                 {

--- a/index.js
+++ b/index.js
@@ -117,15 +117,17 @@ class SlackNotifier extends NotificationBase {
             buildData.event.commit.message;
         const isMinimized = buildData.settings.slack.minimized;
 
-        let message = hoek.reach(buildData,
+        let message = isMinimized ?
+            // eslint-disable-next-line max-len
+            `<${pipelineLink}|${buildData.pipeline.scmRepo.name}#${buildData.jobName}> *${buildData.status}*` :
+            // eslint-disable-next-line max-len
+            `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
+
+        const metaMessage = hoek.reach(buildData,
             'build.meta.notification.message', { default: false });
 
-        if (!message) {
-            message = isMinimized ?
-                // eslint-disable-next-line max-len
-                `<${pipelineLink}|${buildData.pipeline.scmRepo.name}#${buildData.jobName}> *${buildData.status}*` :
-                // eslint-disable-next-line max-len
-                `*${buildData.status}* ${STATUSES_MAP[buildData.status]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
+        if (metaMessage) {
+            message = `${message}\n${metaMessage}`;
         }
 
         const attachments = isMinimized ?

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -250,6 +250,50 @@ describe('index', () => {
             });
         });
 
+        it('sets channels and statuses for simple slack string name with message', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            message: 'Hello!Meta!'
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledOnce(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
         it('sets channels and statuses for an array of channels in config settings', (done) => {
             const buildDataMockArray = {
                 settings: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -267,7 +267,9 @@ describe('index', () => {
                     id: '1234',
                     meta: {
                         notification: {
-                            message: 'Hello!Meta!'
+                            slack: {
+                                message: 'Hello!Meta!'
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
**Issue #, if available:**
It resembles to [1177](https://github.com/screwdriver-cd/screwdriver/issues/1177)

**Description of changes:**
Ower users wants to inject their arbitrarily message to slack notification, to check any values in the middle of building. This PR provide the function to deliver arbitrarily message  by setting meta.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
