### PR TITLE
fix: Update Hapi and node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Notifications (Slack)
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
-> Sends slack notifications on certain build events
+> Sends slack notifications on certain Screwdriver build events
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -34,12 +34,13 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {
+    "@hapi/hapi": "^19.1.1",
     "@slack/client": "^4.3.1",
-    "hapi": "^17.0.0",
     "hoek": "^5.0.2",
     "joi": "^13.4.0",
     "mockery": "^2.1.0",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');


### PR DESCRIPTION
## Context

hapi npm package is deprecated in favor of @hapi/hapi.

## Objective

This PR:
- removes jenkins-mocha in favor of mocha and nyc
- replaces hapi with @hapi/hapi
- replaces node:8 with node:12 in the screwdriver.yaml

## References

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
