### PR TITLE
feat: Allow setting job specific slack message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 .nyc_output 
 package-lock.json
 .vscode
+/.idea

--- a/index.js
+++ b/index.js
@@ -137,17 +137,15 @@ class SlackNotifier extends NotificationBase {
         const metaMessage = hoek.reach(buildData,
             'build.meta.notification.slack.message', { default: false });
 
-        if (metaMessage) {
-            message = `${message}\n${metaMessage}`;
-        }
-
         const metaVar = `build.meta.notification.slack.${buildData.jobName}.message`;
 
         const buildMessage = hoek.reach(buildData, metaVar, { default: false });
 
-        // Job specific slack message takes precedence of generic slack message.
+        // Use job specific message over generic message.
         if (buildMessage) {
             message = `${message}\n${buildMessage}`;
+        } else if (metaMessage) {
+            message = `${message}\n${metaMessage}`;
         }
         const attachments = isMinimized ?
             [

--- a/index.js
+++ b/index.js
@@ -141,6 +141,14 @@ class SlackNotifier extends NotificationBase {
             message = `${message}\n${metaMessage}`;
         }
 
+        const metaVar = `build.meta.notification.slack.${buildData.jobName}.message`;
+
+        const buildMessage = hoek.reach(buildData, metaVar, { default: false });
+
+        // Job specific slack message takes precedence of generic slack message.
+        if (buildMessage) {
+            message = `${message}\n${buildMessage}`;
+        }
         const attachments = isMinimized ?
             [
                 {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -296,6 +296,103 @@ describe('index', () => {
             });
         });
 
+        it('Job specific slack message. No generic slack message', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                publish: {
+                                    message: 'Hello! Publish Meta!'
+                                }
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledOnce(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
+        it('Job specific slack message overwriting the generic message', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                message: 'Hello!Meta!',
+                                publish: {
+                                    message: 'Hello! Publish Meta!'
+                                }
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledOnce(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
         it('sets channels and statuses for an array of channels in config settings', (done) => {
             const buildDataMockArray = {
                 settings: {


### PR DESCRIPTION
Having `notification.slack.message` set is useful for a generic message that is tight to the same event across a pipeline.

https://docs.screwdriver.cd/user-guide/metadata.html#notifications

This isn’t optimal though when you have parallel jobs and the generic message was set in one of the jobs and may only apply to that specific job. The work around is that in every parallel job `notification.slack.message` would have to be reset which adds additional setup to your yaml.

Allowing to overwrite the generic `notification.slack.message` with `notification.slack.<jobName>.message` will make this easier.
In the use cases where job specific slack messages are needed a user can now set `notification.slack.<jobName>.message`, which will overwrite the generic `notification.slack.message`, if it was set.

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
