### PR TITLE
feat: Allow to set slack channel per job dynamically

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,9 +103,10 @@ class SlackNotifier extends NotificationBase {
             return;
         }
 
-        // Slack channel overwrite from meta data
-        const metaDataSlackChannel = hoek.reach(buildData,
-            'build.meta.notification.slack.channels', { default: false });
+        // Slack channel overwrite from meta data. Job specific only.
+        const metaReplaceVar = `build.meta.notification.slack.${buildData.jobName}.channels`;
+
+        const metaDataSlackChannel = hoek.reach(buildData, metaReplaceVar, { default: false });
 
         if (metaDataSlackChannel) {
             buildData.settings.slack = metaDataSlackChannel.split(',');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -411,7 +411,9 @@ describe('index', () => {
                     meta: {
                         notification: {
                             slack: {
-                                channels: 'onlyonce'
+                                publish: {
+                                    channels: 'onlyonce'
+                                }
                             }
                         }
                     }
@@ -439,6 +441,54 @@ describe('index', () => {
             });
         });
 
+        it('channel meta data overwrite. should not overwrite. wrong job name', (done) => {
+            const buildDataMockArray = {
+                settings: {
+                    slack: ['meeseeks', 'second']
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                notpublish: {
+                                    channels: 'onlyonce'
+                                }
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockArray);
+
+            process.nextTick(() => {
+                assert.calledTwice(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
         it('channel meta data overwrite. 1 up to 2 channels', (done) => {
             const buildDataMockArray = {
                 settings: {
@@ -457,7 +507,9 @@ describe('index', () => {
                     meta: {
                         notification: {
                             slack: {
-                                channels: 'onlyonce, secondTime'
+                                publish: {
+                                    channels: 'onlyonce, secondTime'
+                                }
                             }
                         }
                     }
@@ -503,7 +555,9 @@ describe('index', () => {
                     meta: {
                         notification: {
                             slack: {
-                                channels: 'onlyonce,, , ,second,, ,'
+                                publish: {
+                                    channels: 'onlyonce,, , ,second,, ,'
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
`meta set build.meta.notification.slack.{jobname}.channels` can be used to overwrite the yaml defined slack channel.
Overwrites are specific to the current job.
It can be a comma separated string for multiple channels. This will only work to overwrite a yaml set slack channel. It is not a replacement.

This is useful when code inside a SD step decides who should be notified.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
