### PR TITLE
feat(1572): [2] Add FIXED status to the build

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,8 +154,8 @@ class SlackNotifier extends NotificationBase {
             `${buildData.event.commit.message.substring(0, cutOff)}...` :
             buildData.event.commit.message;
         const isMinimized = buildData.settings.slack.minimized;
-        
-        // When using multiple notification plugins,Do not change the `buildData.status` directly 
+
+        // When using multiple notification plugins,Do not change the `buildData.status` directly
         let notificationStatus = buildData.status;
 
         if (buildData.settings.slack.statuses.includes('FAILURE')) {

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ class SlackNotifier extends NotificationBase {
             buildData.event.commit.message;
         const isMinimized = buildData.settings.slack.minimized;
         
-        // When using multiple notification plugins,Do not change the `BuildData.status` directly 
+        // When using multiple notification plugins,Do not change the `buildData.status` directly 
         let notificationStatus = buildData.status;
 
         if (buildData.settings.slack.statuses.includes('FAILURE')) {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const COLOR_MAP = {
     BLOCKED: '#ccc', // Using 'sd-light-gray' from https://github.com/screwdriver-cd/ui/blob/master/app/styles/screwdriver-colors.scss
     UNSTABLE: '#ffd333', // Using 'sd-unstable' from https://github.com/screwdriver-cd/ui/blob/master/app/styles/screwdriver-colors.scss
     COLLAPSED: '#f2f2f2', // New color. Light grey.
+    FIXED: 'good',
     FROZEN: '#acd9ff' // Using 'sd-frozen' from https://github.com/screwdriver-cd/ui/blob/master/app/styles/screwdriver-colors.scss
 };
 const STATUSES_MAP = {
@@ -29,6 +30,7 @@ const STATUSES_MAP = {
     BLOCKED: ':lock:',
     UNSTABLE: ':foggy:',
     COLLAPSED: ':arrow_up:',
+    FIXED: ':sunny:',
     FROZEN: ':snowman:'
 };
 const DEFAULT_STATUSES = ['FAILURE'];
@@ -134,6 +136,10 @@ class SlackNotifier extends NotificationBase {
 
         if (buildData.settings.slack.statuses === undefined) {
             buildData.settings.slack.statuses = DEFAULT_STATUSES;
+        }
+
+        if (buildData.status === 'FIXED') {
+            buildData.settings.slack.statuses.push(buildData.status);
         }
 
         if (!buildData.settings.slack.statuses.includes(buildData.status)) {

--- a/index.js
+++ b/index.js
@@ -144,8 +144,8 @@ class SlackNotifier extends NotificationBase {
             buildData.settings.slack.statuses.push('FIXED');
         }
 
-        // Do not change the `buildData.status` directly.
-        // It affects the behavior of other notification plugins.
+        // Do not change the `buildData.status` directly
+        // It affects the behavior of other notification plugins
         let notificationStatus = buildData.status;
 
         if (buildData.settings.slack.statuses.includes('FAILURE')) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,7 +90,8 @@ describe('index', () => {
                     },
                     sha: '1234567890abcdeffedcba098765432100000000'
                 },
-                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234',
+                isFixed: false
             };
             notifier = new SlackNotifier(configMock);
         });
@@ -98,6 +99,19 @@ describe('index', () => {
         it('verifies that included status creates slack notifier', (done) => {
             serverMock.event(eventMock);
             serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMock);
+
+            process.nextTick(() => {
+                assert.calledWith(WebClientConstructorMock.WebClient, configMock.token);
+                assert.calledThrice(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
+        it('when the build status is fixed, Overwrites the notification status title', (done) => {
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            buildDataMock.isFixed = true;
             serverMock.events.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
@@ -269,52 +283,6 @@ describe('index', () => {
                         notification: {
                             slack: {
                                 message: 'Hello!Meta!'
-                            }
-                        }
-                    }
-                },
-                event: {
-                    id: '12345',
-                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
-                    creator: { username: 'foo' },
-                    commit: {
-                        author: { name: 'foo' },
-                        message: 'fixing a bug'
-                    },
-                    sha: '1234567890abcdeffedcba098765432100000000'
-                },
-                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
-            };
-
-            serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
-            serverMock.events.emit(eventMock, buildDataMockSimple);
-
-            process.nextTick(() => {
-                assert.calledOnce(WebClientMock.chat.postMessage);
-                done();
-            });
-        });
-
-        it('verifies when the build status is FIXED', (done) => {
-            const buildDataMockSimple = {
-                settings: {
-                    slack: 'meeseeks'
-                },
-                status: 'FIXED',
-                pipeline: {
-                    id: '123',
-                    scmRepo: {
-                        name: 'screwdriver-cd/notifications'
-                    }
-                },
-                jobName: 'publish',
-                build: {
-                    id: '1234',
-                    meta: {
-                        notification: {
-                            slack: {
-                                message: 'Hello!FIXED'
                             }
                         }
                     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -296,6 +296,52 @@ describe('index', () => {
             });
         });
 
+        it('verifies when the build status is FIXED', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FIXED',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                message: 'Hello!FIXED'
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledOnce(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
         it('Job specific slack message. No generic slack message', (done) => {
             const buildDataMockSimple = {
                 settings: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
feat: https://github.com/screwdriver-cd/screwdriver/issues/1572

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR adds the status "FIXED" when a build has failed in the past and the build succeeds again.
Notification-slack-plugin receives a build status label (`isFIxed`) from screwdriver api.
Therefore, The "FIXED" status uses the same `COLOR_MAP` and `STATUSES_MAP` as the "SUCCESS" status.

In order for users to receive FIXED notifications, "FAILURE" must be set to screwdriver.yaml.

The image below is a FIXED notification sent by slack.
<img width="311" alt="fixed-slack" src="https://user-images.githubusercontent.com/17828065/90346236-5d013b00-e062-11ea-9703-0e86dd967f47.png">
<img width="287" alt="mini-fixed-slack" src="https://user-images.githubusercontent.com/17828065/90346239-5ffc2b80-e062-11ea-92de-2c24c1b38500.png">
 


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

issue: https://github.com/screwdriver-cd/screwdriver/issues/1572
[1] notifications-email https://github.com/screwdriver-cd/notifications-email/pull/22
[3]  screwdriver-api https://github.com/screwdriver-cd/screwdriver/pull/2182
[4] guide screwdriver-cd/guide#407
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
