### PR TITLE
feat(1958): Upgrade hapi dependencies. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const slacker = require('./slack');
 const NotificationBase = require('screwdriver-notifications-base');
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 
 // This should match what is in https://github.com/screwdriver-cd/data-schema/blob/master/models/build.js#L98
 // https://github.com/screwdriver-cd/ui/blob/master/app/styles/screwdriver-colors.scss
@@ -32,7 +32,7 @@ const STATUSES_MAP = {
     FROZEN: ':snowman:'
 };
 const DEFAULT_STATUSES = ['FAILURE'];
-const SCHEMA_STATUS = Joi.string().valid(Object.keys(COLOR_MAP));
+const SCHEMA_STATUS = Joi.string().valid(...Object.keys(COLOR_MAP));
 const SCHEMA_STATUSES = Joi.array()
     .items(SCHEMA_STATUS)
     .min(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-notifications-slack",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Sends slack notifications on certain build events",
   "main": "index.js",
   "scripts": {
@@ -39,10 +39,10 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "@hapi/hapi": "^19.1.1",
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/hoek": "^9.0.4",
     "@slack/client": "^4.3.1",
-    "hoek": "^5.0.2",
-    "joi": "^13.4.0",
+    "joi": "^17.2.1",
     "mockery": "^2.1.0",
     "request": "^2.87.0",
     "samsam": "^1.3.0",


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
