### PR TITLE
feat(2022): add source dir message

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,12 @@ class SlackNotifier extends NotificationBase {
             // eslint-disable-next-line max-len
             `*${notificationStatus}* ${STATUSES_MAP[notificationStatus]} <${pipelineLink}|${buildData.pipeline.scmRepo.name} ${buildData.jobName}>`;
 
+        const rootDir = hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: false });
+
+        if (rootDir) {
+            message = `${message}\n*Source Directory:* ${buildData.pipeline.scmRepo.rootDir}`;
+        }
+
         const metaMessage = hoek.reach(buildData,
             'build.meta.notification.slack.message', { default: false });
 

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ class SlackNotifier extends NotificationBase {
         const rootDir = hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: false });
 
         if (rootDir) {
-            message = `${message}\n*Source Directory:* ${buildData.pipeline.scmRepo.rootDir}`;
+            message = `${message}\n*Source Directory:* ${rootDir}`;
         }
 
         const metaMessage = hoek.reach(buildData,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -264,6 +264,46 @@ describe('index', () => {
             });
         });
 
+        it('sets channels, statuses and srcDir for simple slack string name', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications',
+                        rootDir: 'mydir'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234'
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledOnce(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
         it('sets channels and statuses for simple slack string name with message', (done) => {
             const buildDataMockSimple = {
                 settings: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add feature https://github.com/screwdriver-cd/screwdriver/issues/2022

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add the `Source Directory` setting as notification message.

Below is example of slack:
<img width="515" alt="Screen_Shot_2020-10-15_at_16_12_56" src="https://user-images.githubusercontent.com/32473622/96089217-79561280-0f01-11eb-95b6-5136f6d3cd12.jpg">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2022
https://github.com/screwdriver-cd/screwdriver/issues/2005

https://github.com/screwdriver-cd/notifications-email/pull/24

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
