### PR TITLE
[2] fix: require screwdriver-data-schema@20.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
 const Joi = require('joi');
 const slacker = require('./slack');
 const NotificationBase = require('screwdriver-notifications-base');
+const schema = require('screwdriver-data-schema');
 const hoek = require('@hapi/hoek');
 
-// This should match what is in https://github.com/screwdriver-cd/data-schema/blob/master/models/build.js#L98
+// This should match what is in https://github.com/screwdriver-cd/data-schema/blob/master/models/build.js#L14
 // https://github.com/screwdriver-cd/ui/blob/master/app/styles/screwdriver-colors.scss
 const COLOR_MAP = {
     ABORTED: 'danger',
@@ -34,9 +35,8 @@ const STATUSES_MAP = {
     FROZEN: ':snowman:'
 };
 const DEFAULT_STATUSES = ['FAILURE'];
-const SCHEMA_STATUS = Joi.string().valid(...Object.keys(COLOR_MAP));
 const SCHEMA_STATUSES = Joi.array()
-    .items(SCHEMA_STATUS)
+    .items(schema.plugins.notifications.schemaStatus)
     .min(0);
 const SCHEMA_SLACK_CHANNEL = Joi.string().required();
 const SCHEMA_SLACK_CHANNELS = Joi.array()
@@ -52,26 +52,10 @@ const SCHEMA_SLACK_SETTINGS = Joi.object().keys({
         SCHEMA_SLACK_CHANNELS, SCHEMA_SLACK_CHANNEL
     ).required()
 }).unknown(true);
-const SCHEMA_SCM_REPO = Joi.object()
-    .keys({
-        name: Joi.string().required()
-    }).unknown(true);
-const SCHEMA_PIPELINE_DATA = Joi.object()
-    .keys({
-        scmRepo: SCHEMA_SCM_REPO.required()
-    }).unknown(true);
 const SCHEMA_BUILD_DATA = Joi.object()
     .keys({
-        settings: SCHEMA_SLACK_SETTINGS.required(),
-        status: SCHEMA_STATUS.required(),
-        pipeline: SCHEMA_PIPELINE_DATA.required(),
-        jobName: Joi.string(),
-        build: Joi.object().keys({
-            id: Joi.number().integer().required()
-        }).unknown(true),
-        event: Joi.object(),
-        buildLink: Joi.string(),
-        isFixed: Joi.boolean()
+        ...schema.plugins.notifications.schemaBuildData,
+        settings: SCHEMA_SLACK_SETTINGS.required()
     });
 const SCHEMA_SLACK_CONFIG = Joi.object()
     .keys({

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mockery": "^2.1.0",
     "request": "^2.87.0",
     "samsam": "^1.3.0",
+    "screwdriver-data-schema": "^20.6.0",
     "screwdriver-notifications-base": "^3.0.0"
   },
   "release": {


### PR DESCRIPTION
## Context
The same definitions exist for both [notification-email](https://github.com/screwdriver-cd/notifications-email/blob/e9906f2601e50cddaf21e80b877992d01332ac34/index.js#L54-L62) and [notification-slack](https://github.com/screwdriver-cd/notifications-slack/blob/59f18306297795c4288591f562a552396ccacd72/index.js#L66-L74), and it is possible that the next time we add a feature, we will miss a fix for one or the other.

## Objective
The definitions that exist in both [notification-email](https://github.com/screwdriver-cd/notifications-email/blob/e9906f2601e50cddaf21e80b877992d01332ac34/index.js#L54-L62) and [notification-slack](https://github.com/screwdriver-cd/notifications-slack/blob/59f18306297795c4288591f562a552396ccacd72/index.js#L66-L74) are combined in one place.

Merging https://github.com/screwdriver-cd/data-schema/pull/420 will create the screwdriver-data-schema@20.6.0 package.

## References
[1] https://github.com/screwdriver-cd/data-schema/pull/420
[2] https://github.com/screwdriver-cd/notifications-slack/pull/33 (this PR require [1])
[3] https://github.com/screwdriver-cd/notifications-email/pull/25


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
