### PR TITLE
Allow setting minimized from within Job

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,12 @@ class SlackNotifier extends NotificationBase {
         const commitMessage = buildData.event.commit.message.length > cutOff ?
             `${buildData.event.commit.message.substring(0, cutOff)}...` :
             buildData.event.commit.message;
-        const isMinimized = buildData.settings.slack.minimized;
+
+        // Slack channel overwrite from meta data. Job specific only.
+        const metaMinimizedReplaceVar =
+            `build.meta.notification.slack.${buildData.jobName}.minimized`;
+        const isMinimized = hoek.reach(buildData, metaMinimizedReplaceVar,
+            { default: buildData.settings.slack.minimized });
 
         let message = isMinimized ?
             // eslint-disable-next-line max-len

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -447,6 +447,159 @@ describe('index', () => {
             });
         });
 
+        it('Check default minimized setting - false -', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234'
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                const resp = WebClientMock.chat.postMessage.firstCall.lastArg;
+
+                assert.isNotNull(resp);
+                assert.isNotNull(resp.attachments);
+                assert.isArray(resp.attachments);
+                assert.isAtLeast(resp.attachments.length, 1);
+                assert.match(resp.attachments[0].text, 'Merge pull request #26');
+                done();
+            });
+        });
+
+        it('Job specific slack message minimized overwrite - false -', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                publish: {
+                                    minimized: false
+                                }
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                const resp = WebClientMock.chat.postMessage.firstCall.lastArg;
+
+                assert.isNotNull(resp);
+                assert.isNotNull(resp.attachments);
+                assert.isArray(resp.attachments);
+                assert.isAtLeast(resp.attachments.length, 1);
+                assert.match(resp.attachments[0].text, 'Merge pull request #26');
+                done();
+            });
+        });
+
+        it('Job specific slack message minimized overwrite - true -', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    slack: 'meeseeks'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                publish: {
+                                    minimized: true
+                                }
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                const resp = WebClientMock.chat.postMessage.firstCall.lastArg;
+
+                assert.isNotNull(resp);
+                assert.isNotNull(resp.attachments);
+                assert.isArray(resp.attachments);
+                assert.isAtLeast(resp.attachments.length, 1);
+                assert.isNaN(resp.attachments[0].text);
+                done();
+            });
+        });
+
         it('channel meta data overwrite. 2 down to 1 channel', (done) => {
             const buildDataMockArray = {
                 settings: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -447,7 +447,7 @@ describe('index', () => {
             });
         });
 
-        it('Check default minimized setting - false -', (done) => {
+        it('verifies the default minimized setting is false.', (done) => {
             const buildDataMockSimple = {
                 settings: {
                     slack: 'meeseeks'
@@ -492,7 +492,7 @@ describe('index', () => {
             });
         });
 
-        it('Job specific slack message minimized overwrite - false -', (done) => {
+        it('verifies minimized is set fo false for a specific job.', (done) => {
             const buildDataMockSimple = {
                 settings: {
                     slack: 'meeseeks'
@@ -546,7 +546,7 @@ describe('index', () => {
             });
         });
 
-        it('Job specific slack message minimized overwrite - true -', (done) => {
+        it('verifies minimized is set to true for a specific job.', (done) => {
             const buildDataMockSimple = {
                 settings: {
                     slack: 'meeseeks'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -492,7 +492,7 @@ describe('index', () => {
             });
         });
 
-        it('verifies minimized is set fo false for a specific job.', (done) => {
+        it('verifies minimized is set to false for a specific job.', (done) => {
             const buildDataMockSimple = {
                 settings: {
                     slack: 'meeseeks'


### PR DESCRIPTION
Using meta data`notification.slack.jobname.minimized` will allow overwriting the default minimized setting from within a job.

Feature request: https://github.com/screwdriver-cd/screwdriver/issues/2284

Documentation: https://github.com/screwdriver-cd/guide/pull/433

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
