### PR TITLE
[1] fix(2051): fix function that does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ class SlackNotifier extends NotificationBase {
     }
 
     static validateConfig(config) {
-        return Joi.validate(config, SCHEMA_SLACK_SETTINGS);
+        return SCHEMA_SLACK_SETTINGS.validate(config);
     }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -951,4 +951,103 @@ describe('index', () => {
             });
         });
     });
+
+    describe('validate config', () => {
+        it('valid config with complete parameters', () => {
+            configMock = {
+                slack: {
+                    channels: ['foo-channel'],
+                    statuses: ['SUCCESS', 'FAILURE'],
+                    minimized: true
+                }
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('valid config with empty statuses', () => {
+            configMock = {
+                slack: {
+                    channels: ['foo-channel'],
+                    statuses: []
+                }
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('valid config with a channel', () => {
+            configMock = {
+                slack: 'foo-channel'
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('valid config with channels', () => {
+            configMock = {
+                slack: ['foo-channel', 'bar-channel']
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('invalid config with empty parameters', () => {
+            configMock = {};
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.name, 'ValidationError');
+        });
+
+        it('valid config with empty slack settings', () => {
+            configMock = {
+                slack: {}
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('valid config without channels', () => {
+            configMock = {
+                slack: {
+                    statuses: ['SUCCESS', 'FAILURE']
+                }
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('invalid config with empty channels', () => {
+            configMock = {
+                slack: {
+                    channels: [],
+                    statuses: ['SUCCESS', 'FAILURE']
+                }
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.name, 'ValidationError');
+        });
+
+        it('invalid unknown status', () => {
+            configMock = {
+                slack: {
+                    channels: ['foo-channel'],
+                    statuses: ['DUMMY_STATUS']
+                }
+            };
+            const { error } = SlackNotifier.validateConfig(configMock);
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.name, 'ValidationError');
+        });
+    });
 });


### PR DESCRIPTION
## Context
Currently, `Joi.validate()` is [not exist](https://github.com/sideway/joi/issues/1941).

```
TypeError: Joi.validate is not a function
```

We shold use [`schema.validate()`](https://github.com/sideway/joi/issues/2145#issuecomment-568173652) instead.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR enables `validateConfig()` for [config-parser](https://github.com/screwdriver-cd/config-parser/pull/105/files).
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2051
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

[1] : this PR
[2] : https://github.com/screwdriver-cd/notifications-email/pull/29
[3]: https://github.com/screwdriver-cd/config-parser/pull/115

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
