### PR TITLE
fix: Update Slack client npm package to web-api v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@hapi/hapi": "^20.0.0",
     "@hapi/hoek": "^9.0.4",
-    "@slack/client": "^4.3.1",
+    "@slack/web-api": "^5.14.0",
     "joi": "^17.2.1",
     "mockery": "^2.1.0",
     "request": "^2.87.0",

--- a/slack.js
+++ b/slack.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { WebClient } = require('@slack/client');
+const { WebClient } = require('@slack/web-api');
 
 let web;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,7 +42,7 @@ describe('index', () => {
         WebClientConstructorMock = {
             WebClient: sinon.stub().returns(WebClientMock)
         };
-        mockery.registerMock('@slack/client', WebClientConstructorMock);
+        mockery.registerMock('@slack/web-api', WebClientConstructorMock);
 
         // eslint-disable-next-line global-require
         SlackNotifier = require('../index');

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -40,7 +40,7 @@ describe('slack', () => {
         WebClientConstructorMock = {
             WebClient: sinon.stub().returns(WebClientMock)
         };
-        mockery.registerMock('@slack/client', WebClientConstructorMock);
+        mockery.registerMock('@slack/web-api', WebClientConstructorMock);
 
         // eslint-disable-next-line global-require
         slacker = require('../slack');


### PR DESCRIPTION
## Context

`@slack/client` npm package has been deprecated in favor of `@slack/web-api`: https://www.npmjs.com/package/@slack/client

## Objective

This PR updates the npm package to use latest `@slack/web-api`

## References

See https://github.com/screwdriver-cd/notifications-slack/pull/39

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
