### PR TITLE
fix: set the link to /pipelines/{id}/pulls for PR builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,9 @@ function buildStatus(buildData, config) {
         return;
     }
 
-    const pipelineLink = buildData.buildLink.split('/builds')[0];
+    const pipelineLink = /^PR-/.test(buildData.jobName)
+        ? `${buildData.buildLink.split('/builds')[0]}/pulls`
+        : buildData.buildLink.split('/builds')[0];
     const truncatedSha = buildData.event.sha.slice(0, 6);
     const cutOff = 150;
     const commitMessage =


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Even PR builds have a link to `/pipelines/{id}` in slack messages.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
For PR builds, set the link to `/pipelines/{id}/pulls` which is the page with the Pull Requests tab selected.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
