### PR TITLE
[1] feat(2505): multi workspace slack notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,16 @@ const SCHEMA_JOB_DATA = Joi.object().keys({
     settings: SCHEMA_SLACK_SETTINGS.required()
 });
 const SCHEMA_SLACK_CONFIG = Joi.object().keys({
-    token: Joi.string().required()
+    defaultWorkspace: Joi.string().required(),
+    workspaces: Joi.object()
+        .unknown()
+        .pattern(
+            Joi.string(),
+            Joi.object().keys({
+                token: Joi.string().required()
+            })
+        )
+        .required()
 });
 
 /**
@@ -205,7 +214,7 @@ function buildStatus(buildData, config) {
         attachments
     };
 
-    slacker(config.token, buildData.settings.slack.channels, slackMessage);
+    slacker(config, buildData.settings.slack.channels, slackMessage);
 }
 
 /**
@@ -251,7 +260,7 @@ function jobStatus(jobData, config) {
         message
     };
 
-    slacker(config.token, jobData.settings.slack.channels, slackMessage);
+    slacker(config, jobData.settings.slack.channels, slackMessage);
 }
 
 class SlackNotifier extends NotificationBase {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-notifications-slack",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Sends slack notifications on certain build events",
   "main": "index.js",
   "scripts": {

--- a/slack.js
+++ b/slack.js
@@ -2,47 +2,89 @@
 
 const { WebClient } = require('@slack/web-api');
 const logger = require('screwdriver-logger');
+const webClients = {};
 
-let web;
+/**
+ * Parse slack config
+ * @method parseSlackConfig
+ * @param {Object}      config                  slack config
+ * @param {String}      config.defaultWorkspace default slack workspace
+ * @param {Object}      config.workspaces       slack workspaces config
+ * @param {String}      channelConfig           slack channel name (ex. channel1, workspace1:channel2)
+ * @return {Object}
+ */
+function parseSlackConfig(config, channelConfig) {
+    let workspace = config.defaultWorkspace;
+    let channel = channelConfig;
+
+    if (channel.includes(':')) {
+        [workspace, channel] = channel.split(':');
+    }
+
+    const workspaceConfig = config.workspaces[workspace];
+
+    if (!workspaceConfig) {
+        logger.error(`Cannot find slack token of ${workspace}.`);
+
+        return {};
+    }
+
+    return { workspace, channel, token: workspaceConfig.token };
+}
 
 /**
  * Post message to a specific channel
  * @method postMessage
- * @param {String} channelName      name of the channel
+ * @param {String} channel          name of the channel
+ * @param {Object} web              slack web client
  * @param {Object} payload          payload of the slack message
  * @return {Promise}
  */
-function postMessage(channelName, payload) {
+function postMessage(channel, web, payload) {
     // Can post to channel name directly https://api.slack.com/methods/chat.postMessage#channels
     return web.chat
         .postMessage({
-            channel: channelName,
+            channel,
             text: payload.message,
             as_user: true,
             attachments: payload.attachments
         })
-        .catch(err => logger.error(`postMessage: failed to notify Slack channel ${channelName}: ${err.message}`));
+        .catch(err => logger.error(`postMessage: failed to notify Slack channel ${channel}: ${err.message}`));
 }
 
 /**
  * Sends slack message to slack channels
- * @param {String}      token                   access token for slack
+ * @param {Object}      config                  slack config
+ * @param {String}      config.defaultWorkspace default slack workspace
+ * @param {Object}      config.workspaces       slack workspaces config
  * @param {String[]}    channels                slack channel names
  * @param {Object}      payload                 slack message payload
  * @return {Promise}
  */
-function slacker(token, channels, payload) {
-    if (!web) {
-        web = new WebClient(token, {
-            retryConfig: {
-                retries: 5,
-                factor: 3.86,
-                maxRetryTime: 30 * 60 * 1000 // Set maximum time to 30 min that the retried operation is allowed to run
-            }
-        });
-    }
+function slacker(config, channels, payload) {
+    return Promise.all(
+        channels.map(channelConfig => {
+            const { workspace, channel, token } = parseSlackConfig(config, channelConfig);
 
-    return Promise.all(channels.map(channelName => postMessage(channelName, payload)));
+            if (!workspace || !token) {
+                return Promise.resolve();
+            }
+
+            if (!webClients[workspace]) {
+                webClients[workspace] = new WebClient(token, {
+                    retryConfig: {
+                        retries: 5,
+                        factor: 3.86,
+                        maxRetryTime: 30 * 60 * 1000 // Set maximum time to 30 min that the retried operation is allowed to run
+                    }
+                });
+            }
+
+            const web = webClients[workspace];
+
+            return postMessage(channel, web, payload);
+        })
+    );
 }
 
 module.exports = slacker;

--- a/slack.js
+++ b/slack.js
@@ -24,7 +24,7 @@ function parseSlackConfig(config, channelConfig) {
     const workspaceConfig = config.workspaces[workspace];
 
     if (!workspaceConfig) {
-        logger.error(`Cannot find slack token of ${workspace}.`);
+        logger.error(`Cannot find Slack token for ${workspace}.`);
 
         return {};
     }

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -5,6 +5,7 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
+
 describe('slack', () => {
     let configMock;
     let channels;
@@ -12,6 +13,7 @@ describe('slack', () => {
     let slacker;
     let WebClientMock;
     let WebClientConstructorMock;
+    let loggerMock;
 
     before(() => {
         mockery.enable({
@@ -22,20 +24,6 @@ describe('slack', () => {
 
     beforeEach(() => {
         WebClientMock = {
-            channels: {
-                list: sinon.stub().resolves({
-                    channels: [
-                        {
-                            name: 'meeseeks',
-                            id: '23'
-                        },
-                        {
-                            name: 'dd',
-                            id: '21'
-                        }
-                    ]
-                })
-            },
             chat: {
                 postMessage: sinon.stub().resolves({})
             }
@@ -44,6 +32,11 @@ describe('slack', () => {
             WebClient: sinon.stub().returns(WebClientMock)
         };
         mockery.registerMock('@slack/web-api', WebClientConstructorMock);
+
+        loggerMock = {
+            error: sinon.stub().resolves()
+        };
+        mockery.registerMock('screwdriver-logger', loggerMock);
 
         // eslint-disable-next-line global-require
         slacker = require('../slack');
@@ -61,7 +54,11 @@ describe('slack', () => {
     describe('slacker posts message to channels', () => {
         beforeEach(() => {
             configMock = {
-                token: 'y353e5y45'
+                defaultWorkspace: 'test-workspace1',
+                workspaces: {
+                    'test-workspace1': { token: 'test-token1' },
+                    'test-workspace2': { token: 'test-token2' }
+                }
             };
             channels = ['meeseeks', 'caaaandoooo'];
             payload = {
@@ -71,12 +68,12 @@ describe('slack', () => {
         });
 
         it('does not create client again if there is one', () =>
-            slacker(configMock.token, channels, payload)
-                .then(slacker(configMock.token, channels, payload))
+            slacker(configMock, channels, payload)
+                .then(slacker(configMock, channels, payload))
                 .then(assert.calledOnce(WebClientConstructorMock.WebClient)));
 
         it('gets correct channel ids and post message to channels', () =>
-            slacker(configMock.token, channels, payload).then(() => {
+            slacker(configMock, channels, payload).then(() => {
                 assert.calledTwice(WebClientMock.chat.postMessage);
                 assert.calledWith(WebClientMock.chat.postMessage.firstCall, {
                     channel: 'meeseeks',
@@ -95,10 +92,84 @@ describe('slack', () => {
         it('logs an error if cannt post message to channels', () => {
             WebClientMock.chat.postMessage.rejects(new Error('error!'));
 
-            return slacker(configMock.token, channels, payload).then(() => {
-                it('should catch an error', () => {
-                    // eslint-disable-next-line no-console
-                    assert.calledTwice(console.error);
+            return slacker(configMock, channels, payload).then(() => {
+                assert.calledTwice(loggerMock.error);
+            });
+        });
+
+        it('logs an error if cannot find the workspace', () => {
+            const invalidChannels = ['unknown-workspace:foo', 'bar', 'test-workspace2:baz', 'unknown-workspace:qux'];
+
+            return slacker(configMock, invalidChannels, payload).then(() => {
+                assert.calledTwice(loggerMock.error);
+            });
+        });
+
+        describe('slacker posts message to multi workspaces', () => {
+            let WebClientMock1;
+            let WebClientMock2;
+
+            beforeEach(() => {
+                WebClientMock1 = {
+                    chat: {
+                        postMessage: sinon.stub().resolves({})
+                    }
+                };
+                WebClientMock2 = {
+                    chat: {
+                        postMessage: sinon.stub().resolves({})
+                    }
+                };
+
+                WebClientConstructorMock.WebClient.withArgs('test-token1', sinon.match.any).returns(WebClientMock1);
+                WebClientConstructorMock.WebClient.withArgs('test-token2', sinon.match.any).returns(WebClientMock2);
+
+                channels = ['foo', 'test-workspace2:bar', 'test-workspace1:bar', 'test-workspace2:baz'];
+            });
+
+            it('does not create client again if there is one', async () => {
+                await slacker(configMock, channels, payload);
+
+                assert.calledTwice(WebClientConstructorMock.WebClient);
+                assert.calledWith(
+                    WebClientConstructorMock.WebClient.firstCall,
+                    configMock.workspaces['test-workspace1'].token
+                );
+                assert.calledWith(
+                    WebClientConstructorMock.WebClient.secondCall,
+                    configMock.workspaces['test-workspace2'].token
+                );
+            });
+
+            it('send correct workspace client and post message to channels', async () => {
+                await slacker(configMock, channels, payload);
+
+                assert.calledTwice(WebClientMock1.chat.postMessage);
+                assert.calledWith(WebClientMock1.chat.postMessage.firstCall, {
+                    channel: 'foo',
+                    text: payload.message,
+                    as_user: true,
+                    attachments: payload.attachments
+                });
+                assert.calledWith(WebClientMock1.chat.postMessage.secondCall, {
+                    channel: 'bar',
+                    text: payload.message,
+                    as_user: true,
+                    attachments: payload.attachments
+                });
+
+                assert.calledTwice(WebClientMock2.chat.postMessage);
+                assert.calledWith(WebClientMock2.chat.postMessage.firstCall, {
+                    channel: 'bar',
+                    text: payload.message,
+                    as_user: true,
+                    attachments: payload.attachments
+                });
+                assert.calledWith(WebClientMock2.chat.postMessage.secondCall, {
+                    channel: 'baz',
+                    text: payload.message,
+                    as_user: true,
+                    attachments: payload.attachments
                 });
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

**BREAKING CHANGE: Slack notification config is changed. It must be changed to the new configuration format.**

This PR is the implementation of this.
https://github.com/screwdriver-cd/screwdriver/issues/2505#issuecomment-1668815410

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Support multi workspace slack notification.
Users can specify a workspace as bellow:

```yaml
settings:
  slack:
    channels:
      - test-channel-1  # Send to test-channel-1 in default workspace.
      - workspace1:test-channel-2  # Send to test-channel-2 in workspace1
      - workspace2:test-channel-1  # Send to test-channel-1 in workspace2
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue 
- https://github.com/screwdriver-cd/screwdriver/issues/2505

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
