### PR TITLE
feat: skip post slack notification when meta.channel is empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function buildStatus(buildData, config) {
 
     let channelReplacement;
 
-    if (metaDataSlackChannel) {
+    if (metaDataSlackChannel !== false) {
         channelReplacement = metaDataSlackChannel.split(',');
         // Remove empty/blank items.
         channelReplacement = channelReplacement.filter(x => x.trim() !== '');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -774,6 +774,54 @@ describe('index', () => {
             });
         });
 
+        it('channel meta data overwrite. All channels down by empty string', done => {
+            const buildDataMockArray = {
+                settings: {
+                    slack: ['meeseeks', 'second']
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        notification: {
+                            slack: {
+                                publish: {
+                                    channels: ''
+                                }
+                            }
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    },
+                    sha: '1234567890abcdeffedcba098765432100000000'
+                },
+                buildLink: 'http://thisisaSDtest.com/pipelines/12/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
+            serverMock.events.emit(eventMock, buildDataMockArray);
+
+            process.nextTick(() => {
+                assert.notCalled(WebClientMock.chat.postMessage);
+                done();
+            });
+        });
+
         it('channel meta data overwrite. should not overwrite. wrong job name', done => {
             const buildDataMockArray = {
                 settings: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Sometime, uses want to skip slack notifications.
However, they cannot control whether slack notifications are sent using metadata of `notification.slack.${SD_JOB_NAME}.channels`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR allows uses to skip slack notifications by setting an empty string in the metadata as shown below.

```yaml
jobs:
  not-notify:
    requires: [ ~commit ]
    image: node:20
    settings:
      slack:
        channels:
          - your-channel
        statuses:
          - SUCCESS
    steps:
      - echo: meta set notification.slack.${SD_JOB_NAME}.channels ""
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
