### PR TITLE
fix: bump @slack/web-api to 7.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@hapi/hapi": "^21.0.0",
     "@hapi/hoek": "^11.0.7",
-    "@slack/web-api": "^7.8.0",
+    "@slack/web-api": "^7.15.1",
     "joi": "^17.13.3",
     "screwdriver-data-schema": "^25.0.0",
     "screwdriver-logger": "^3.0.0",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR is created to address a security vulnerability in axios.

The current dependency tree includes an older version of axios via @slack/web-api, which is affected by this issue.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Update @slack/web-api to version 7.15.1, which includes axios 1.15.0.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%407.15.1

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
